### PR TITLE
Add warning about "subrepo" branch conflict

### DIFF
--- a/doc/git-subrepo.swim
+++ b/doc/git-subrepo.swim
@@ -76,7 +76,9 @@ The best short answer is:
 
 The complete "Installation Instructions" can be found below.
 
-Note: git-subrepo needs a git version (> 2.7) that supports worktree:s.
+Notes:
+* git-subrepo needs a git version (> 2.7) that supports worktree:s.
+* some commands may break if the repository contains a branch named "subrepo".
 
 = Commands
 


### PR DESCRIPTION
Please add a warning to the documentation to inform the user about the current gitrepo limitation when a branch named "subrepo" until it can be fixed.
Related to issue https://github.com/ingydotnet/git-subrepo/issues/299
I don't know how to properly update the rest of the documentation, so I may need some help for that.