### PR TITLE
Update error function to allow multiple arguments

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1917,7 +1917,7 @@ usage-error() {
 
 # Nicely report common error messages:
 error() {
-  echo -e "git-subrepo: $1" >&2
+  echo -e "git-subrepo:" $@ >&2
   exit 1
 }
 


### PR DESCRIPTION
Fixes #517 and other issues in which some invocations of `error()` pass multiple arguments which are then silently ignored.